### PR TITLE
Promote 'Update Gist' button to top bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "reqjs": "^1.0.3",
     "svelte": "^1.30.0",
     "v-tippy": "^1.0.0",
-    "vue-feather-icons": "^0.1.1",
+    "vue-feather-icons": "^4.5.0",
     "vue-ga": "^1.0.0",
     "vue-inline": "^1.0.1",
     "vue-router": "^2.7.0",

--- a/src/components/HomeHeader.vue
+++ b/src/components/HomeHeader.vue
@@ -117,7 +117,7 @@
             command="fork-gist"
             v-if="$route.name === 'gist' && isLoggedIn">
             <div class="fake-anchor">
-              <file-plus-icon></file-plus-icon> Fork Gist
+              <git-branch-icon></git-branch-icon> Fork Gist
             </div>
           </el-dropdown-item>
           <el-dropdown-item style="padding: 0;">
@@ -159,8 +159,7 @@
   import notie from 'notie'
   import {
     GithubIcon,
-    FileIcon,
-    FilePlusIcon,
+    GitBranchIcon,
     Link2Icon,
     SaveIcon,
     TwitterIcon,
@@ -301,8 +300,7 @@
       'el-badge': Badge,
       'el-checkbox': Checkbox,
       GithubIcon,
-      FileIcon,
-      FilePlusIcon,
+      GitBranchIcon,
       Link2Icon,
       SaveIcon,
       TwitterIcon,

--- a/src/components/HomeHeader.vue
+++ b/src/components/HomeHeader.vue
@@ -90,7 +90,8 @@
         size="mini"
         plain
         :disabled="editorStatus === 'saving'"
-        v-tippy="{title: isLoggedIn ? 'Save Gist' : 'Save anonymous gist', position: 'bottom'}"
+        :title="isLoggedIn ? 'Save Gist' : 'Save anonymous gist'"
+        v-tippy="{position: 'bottom'}"
         class="home-header-right-item"
         @click="saveGist">
         Save
@@ -111,7 +112,10 @@
               <github-icon v-else /> GitHub {{ githubToken ? 'Logout' : 'Login' }}
             </div>
           </el-dropdown-item>
-          <el-dropdown-item :disabled="editorStatus === 'saving'" command="fork-gist" v-if="$route.name === 'gist'">
+          <el-dropdown-item
+            :disabled="editorStatus === 'saving'"
+            command="fork-gist"
+            v-if="$route.name === 'gist' && isLoggedIn">
             <div class="fake-anchor">
               <file-plus-icon></file-plus-icon> Fork Gist
             </div>

--- a/src/components/HomeHeader.vue
+++ b/src/components/HomeHeader.vue
@@ -86,13 +86,14 @@
         Run
       </el-button>
       <el-button
-        v-if="canUpdateGist"
-        :icon="editorStatus === 'saving' ? 'el-icon-loading' : 'el-icon-upload'"
+        :icon="editorStatus === 'saving' ? 'el-icon-loading' : 'el-icon-upload2'"
         size="mini"
         plain
-        v-tippy="{title: 'Update this gist', position: 'bottom', arrow: true}"
+        :disabled="editorStatus === 'saving'"
+        v-tippy="{title: isLoggedIn ? 'Save Gist' : 'Save anonymous gist', position: 'bottom'}"
         class="home-header-right-item"
-        @click="updateGist">
+        @click="saveGist">
+        Save
       </el-button>
       <el-dropdown
         v-if="!inIframe"
@@ -100,7 +101,7 @@
         @command="handleDropdownCommand"
         trigger="click">
         <el-button
-          :icon="!canUpdateGist && editorStatus === 'saving' ? 'el-icon-loading' : 'el-icon-more'"
+          icon="el-icon-more"
           size="mini">
         </el-button>
         <el-dropdown-menu slot="dropdown">
@@ -110,14 +111,9 @@
               <github-icon v-else /> GitHub {{ githubToken ? 'Logout' : 'Login' }}
             </div>
           </el-dropdown-item>
-          <el-dropdown-item command="save-anonymous-gist">
+          <el-dropdown-item :disabled="editorStatus === 'saving'" command="fork-gist" v-if="$route.name === 'gist'">
             <div class="fake-anchor">
-              <file-icon></file-icon> Save Anonymous Gist
-            </div>
-          </el-dropdown-item>
-          <el-dropdown-item command="save-gist">
-            <div class="fake-anchor">
-              <file-plus-icon></file-plus-icon> Save New Gist
+              <file-plus-icon></file-plus-icon> Fork Gist
             </div>
           </el-dropdown-item>
           <el-dropdown-item style="padding: 0;">
@@ -151,7 +147,7 @@
 </template>
 
 <script>
-  import { mapState, mapActions } from 'vuex'
+  import { mapState, mapActions, mapGetters } from 'vuex'
   import { Button, Input, Badge, Dropdown, DropdownMenu, DropdownItem, MessageBox, Checkbox } from 'element-ui'
   import Event from '@/utils/event'
   import popup from '@/utils/popup'
@@ -183,9 +179,7 @@
       ...mapState({
         totalLogsCount: state => state.logs.length
       }),
-      canUpdateGist() {
-        return this.$route.name === 'gist' && this.githubToken
-      },
+      ...mapGetters(['isLoggedIn']),
       iframeStatusIcon() {
         switch (this.iframeStatus) {
           case 'loading':
@@ -243,18 +237,12 @@
       runCode() {
         Event.$emit('run')
       },
-      updateGist() {
-        Event.$emit('save-gist', true)
+      saveGist() {
+        Event.$emit('save-gist')
       },
       handleDropdownCommand(command) {
-        if (command === 'save-gist') {
-          if (this.githubToken) {
-            Event.$emit('save-gist')
-          } else {
-            this.githubLogin()
-          }
-        } else if (command === 'save-anonymous-gist') {
-          Event.$emit('save-anonymous-gist')
+        if (command === 'fork-gist') {
+          Event.$emit('save-gist', true)
         } else if (command === 'github-login') {
           if (this.githubToken) {
             this.$store.dispatch('setGitHubToken', null)

--- a/src/components/HomeHeader.vue
+++ b/src/components/HomeHeader.vue
@@ -114,10 +114,10 @@
           </el-dropdown-item>
           <el-dropdown-item
             :disabled="editorStatus === 'saving'"
-            command="fork-gist"
-            v-if="$route.name === 'gist' && isLoggedIn">
+            command="save-new-gist"
+            v-if="canUpdateGist">
             <div class="fake-anchor">
-              <git-branch-icon></git-branch-icon> Fork Gist
+              <git-branch-icon></git-branch-icon> Save new
             </div>
           </el-dropdown-item>
           <el-dropdown-item style="padding: 0;">
@@ -182,7 +182,7 @@
       ...mapState({
         totalLogsCount: state => state.logs.length
       }),
-      ...mapGetters(['isLoggedIn']),
+      ...mapGetters(['isLoggedIn', 'canUpdateGist']),
       iframeStatusIcon() {
         switch (this.iframeStatus) {
           case 'loading':
@@ -244,7 +244,7 @@
         Event.$emit('save-gist')
       },
       handleDropdownCommand(command) {
-        if (command === 'fork-gist') {
+        if (command === 'save-new-gist') {
           Event.$emit('save-gist', true)
         } else if (command === 'github-login') {
           if (this.githubToken) {

--- a/src/components/HomeHeader.vue
+++ b/src/components/HomeHeader.vue
@@ -90,7 +90,7 @@
         size="mini"
         plain
         :disabled="editorStatus === 'saving'"
-        :title="isLoggedIn ? 'Save Gist' : 'Save anonymous gist'"
+        :title="saveButtonTitle"
         v-tippy="{position: 'bottom'}"
         class="home-header-right-item"
         @click="saveGist">
@@ -115,6 +115,8 @@
           <el-dropdown-item
             :disabled="editorStatus === 'saving'"
             command="save-new-gist"
+            title="Create a new gist from editor"
+            v-tippy="{position: 'left',arrow: true}"
             v-if="canUpdateGist">
             <div class="fake-anchor">
               <git-branch-icon></git-branch-icon> Save new
@@ -192,6 +194,12 @@
           default:
             return 'el-icon-refresh'
         }
+      },
+      saveButtonTitle() {
+        if (this.isLoggedIn) {
+          return this.canUpdateGist ? 'Update this gist' : 'Create new gist'
+        }
+        return 'Save anonymous gist'
       }
     },
     mounted() {

--- a/src/components/OutputPan.vue
+++ b/src/components/OutputPan.vue
@@ -112,8 +112,8 @@ export default {
         ...style
       }
     })
-    Event.$on('save-gist', fork => {
-      this.saveGist({ token: this.githubToken, fork })
+    Event.$on('save-gist', saveNew => {
+      this.saveGist({ token: this.githubToken, saveNew })
     })
   },
   beforeDestroy() {
@@ -223,7 +223,7 @@ export default {
      * When you are not logged in (no github token) it saves as guest gist
      * Otherwise it creates or updates gist
      */
-    async saveGist({ token, fork } = {}) {
+    async saveGist({ token, saveNew } = {}) {
       this.editorSaving()
       try {
         const files = makeGist(
@@ -242,7 +242,7 @@ export default {
           // eslint-disable-next-line camelcase
           params.access_token = token
         }
-        const shouldUpdateGist = this.canUpdateGist && !fork
+        const shouldUpdateGist = this.canUpdateGist && !saveNew
         const url = `https://api.github.com/gists${
           shouldUpdateGist ?
           `/${this.$route.params.gist}` :

--- a/src/components/OutputPan.vue
+++ b/src/components/OutputPan.vue
@@ -15,7 +15,7 @@
 </template>
 
 <script>
-import { mapState, mapActions } from 'vuex'
+import { mapState, mapActions, mapGetters } from 'vuex'
 import { getHumanlizedTransformerName } from '@/utils'
 import axios from 'axios'
 import notie from 'notie'
@@ -90,6 +90,10 @@ export default {
       'githubToken',
       'iframeStatus'
     ]),
+    ...mapGetters([
+      'isLoggedIn',
+      'canUpdateGist'
+    ]),
     isActivePan() {
       return this.activePan === 'output'
     }
@@ -108,11 +112,8 @@ export default {
         ...style
       }
     })
-    Event.$on('save-gist', update => {
-      this.saveGist({ token: this.githubToken, update })
-    })
-    Event.$on('save-anonymous-gist', () => {
-      this.saveGist()
+    Event.$on('save-gist', fork => {
+      this.saveGist({ token: this.githubToken, fork })
     })
   },
   beforeDestroy() {
@@ -217,7 +218,12 @@ export default {
       })
     },
 
-    async saveGist({ token, update } = {}) {
+    /**
+     * Save gist
+     * When you are not logged in (no github token) it saves as guest gist
+     * Otherwise it creates or updates gist
+     */
+    async saveGist({ token, fork } = {}) {
       this.editorSaving()
       try {
         const files = makeGist(
@@ -236,9 +242,13 @@ export default {
           // eslint-disable-next-line camelcase
           params.access_token = token
         }
-        const gistId = this.$route.params.gist
-        const url = `https://api.github.com/gists${update ? `/${gistId}` : ''}`
-        const method = update ? 'PATCH' : 'POST'
+        const shouldUpdateGist = this.canUpdateGist && !fork
+        const url = `https://api.github.com/gists${
+          shouldUpdateGist ?
+          `/${this.$route.params.gist}` :
+          ''
+        }`
+        const method = shouldUpdateGist ? 'PATCH' : 'POST'
         const { data } = await axios(url, {
           params,
           method,
@@ -248,7 +258,7 @@ export default {
           }
         })
 
-        if (update) {
+        if (shouldUpdateGist) {
           this.editorSaved()
         } else {
           this.$router.push(`/gist/${data.id}`)

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -242,7 +242,7 @@ const store = new Vuex.Store({
         localStorage.removeItem('codepan:gh-token')
       }
       commit('SET_USER_META', userMeta)
-      if (userMeta.keys().length > 0) {
+      if (Object.keys(userMeta).length > 0) {
         localStorage.setItem('codepan:user-meta', JSON.stringify(userMeta))
       } else {
         localStorage.removeItem('codepan:user-meta')
@@ -265,6 +265,16 @@ const store = new Vuex.Store({
     },
     setIframeStatus({ commit }, status) {
       commit('SET_IFRAME_STATUS', status)
+    }
+  },
+  getters: {
+    isLoggedIn({ githubToken }) {
+      return Boolean(githubToken)
+    },
+    canUpdateGist({ gistMeta, userMeta }) {
+      return gistMeta && userMeta &&
+        gistMeta.owner &&
+        gistMeta.owner.id === userMeta.id
     }
   }
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -7221,9 +7221,9 @@ vm-browserify@0.0.4:
   dependencies:
     indexof "0.0.1"
 
-vue-feather-icons@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/vue-feather-icons/-/vue-feather-icons-0.1.1.tgz#360cefc2a8a6f99912e4b8f82d7fbc04056063c3"
+vue-feather-icons@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/vue-feather-icons/-/vue-feather-icons-4.5.0.tgz#1aec9f4a512d7e79fc5a1df38b62b4192b052059"
   dependencies:
     babel-helper-vue-jsx-merge-props "^2.0.2"
 


### PR DESCRIPTION
Fixes #54 

To test:
1. Log in with GitHub
2. Open a Gist
3. The 'Update' button should now be visible in the top bar
4. When clicked, the button should show a loading indicator

This PR also changes the icon to Element UI's `upload` icon in order to better fit in with the rest of the top bar buttons. `upload` also matches the function of the button better than the previous icon.