### PR TITLE
Store metadata about user and Gist

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -60,7 +60,7 @@ const store = new Vuex.Store({
     autoRun: false,
     githubToken: localStorage.getItem('codepan:gh-token') || '',
     gistMeta: {},
-    userMeta: {},
+    userMeta: JSON.parse(localStorage.getItem('codepan:user-meta')) || {},
     editorStatus: 'saved',
     iframeStatus: null
   },
@@ -232,19 +232,20 @@ const store = new Vuex.Store({
       delete data.files
       commit('SET_GIST_META', data)
     },
-    async setUser({ commit, state }) {
-      const data = await api('user', state.githubToken)
-      if (!data) return
-
-      commit('SET_USER_META', data)
-    },
     async setGitHubToken({ commit, dispatch }, token) {
       commit('SET_GITHUB_TOKEN', token)
+      let userMeta = {}
       if (token) {
         localStorage.setItem('codepan:gh-token', token)
-        await dispatch('setUser')
+        userMeta = await api('user', token)
       } else {
         localStorage.removeItem('codepan:gh-token')
+      }
+      commit('SET_USER_META', userMeta)
+      if (userMeta.keys().length > 0) {
+        localStorage.setItem('codepan:user-meta', JSON.stringify(userMeta))
+      } else {
+        localStorage.removeItem('codepan:user-meta')
       }
     },
     editorSaved({ commit }) {

--- a/src/utils/github-api.js
+++ b/src/utils/github-api.js
@@ -38,4 +38,6 @@ export default async function (endpoint, token, errCb = () => {}) {
       })
     }
   }
+
+  return {}
 }

--- a/src/utils/github-api.js
+++ b/src/utils/github-api.js
@@ -1,0 +1,41 @@
+import axios from 'axios'
+import notie from 'notie'
+
+export default async function (endpoint, token, errCb = () => {}) {
+  const params = {
+    // eslint-disable-next-line camelcase
+    access_token: token
+  }
+
+  try {
+    const data = await axios.get(`https://api.github.com/${endpoint}`, {
+      params
+    }).then(res => res.data)
+
+    return data
+  } catch (err) {
+    errCb()
+    if (err.response) {
+      const { headers, status } = err.response
+      if (!token && status === 403 && headers['x-ratelimit-remaining'] === '0') {
+        notie.confirm({
+          text: 'API rate limit exceeded, do you want to login?',
+          submitCallback() {
+            Event.$emit('showLogin')
+          }
+        })
+      } else {
+        notie.alert({
+          type: 'error',
+          text: err.response.data.message,
+          time: 5
+        })
+      }
+    } else {
+      notie.alert({
+        type: 'error',
+        text: err.message || 'GitHub API Error'
+      })
+    }
+  }
+}

--- a/src/views/EditorPage.vue
+++ b/src/views/EditorPage.vue
@@ -119,6 +119,8 @@ export default {
     }
   },
   mounted() {
+    this.$store.dispatch('setUser')
+
     // Tell the parent window we're ready!
     if (inIframe) {
       window.parent.postMessage({ type: 'codepan-ready' }, '*')

--- a/src/views/EditorPage.vue
+++ b/src/views/EditorPage.vue
@@ -119,8 +119,6 @@ export default {
     }
   },
   mounted() {
-    this.$store.dispatch('setUser')
-
     // Tell the parent window we're ready!
     if (inIframe) {
       window.parent.postMessage({ type: 'codepan-ready' }, '*')


### PR DESCRIPTION
Store the complete API response for Gist and user calls, so we can later access things like logged in username, Gist owner, and many more.

This will allow for things like:
* Show save button only when the Gist is owned by the logged in user (https://github.com/egoist/codepan/pull/56#issuecomment-361039965)
* Display logged in username (https://github.com/egoist/codepan/issues/36)
* Show links for starring and commenting on Gists
* Show owner of Gist and forking link if it's not owned by the logged in user

and so on

This PR also pulls out the logic for GH API calls into a util module