### PR TITLE
add %c handling to console, add color support for proxy console

### DIFF
--- a/src/components/ConsolePan.vue
+++ b/src/components/ConsolePan.vue
@@ -23,7 +23,7 @@
         class="console-log cm-s-default"
         :class="`console-log-${log.type}`"
         :key="index"
-        v-html="highlight(log.message)"
+        v-html="log.message"
         v-for="(log, index) in logs">
       </div>
     </div>
@@ -37,7 +37,6 @@
   import panPosition from '@/utils/pan-position'
   import PanResizer from '@/components/PanResizer.vue'
   import { hasNextPan } from '@/utils'
-  import CodeMirror from 'codemirror'
   import '@/utils/highlight'
   import Event from '@/utils/event'
 
@@ -79,10 +78,7 @@
       }
     },
     methods: {
-      ...mapActions(['clearLogs', 'setActivePan']),
-      highlight(value) {
-        return CodeMirror.highlight(value, { mode: 'javascript' })
-      }
+      ...mapActions(['clearLogs', 'setActivePan'])
     },
     components: {
       'el-badge': Badge,

--- a/src/components/OutputPan.vue
+++ b/src/components/OutputPan.vue
@@ -141,7 +141,7 @@ export default {
         if (data.method === 'clear') {
           this.clearLogs()
         } else {
-          this.addLog({ type: data.method, message: data.args.join('\\n') })
+          this.addLog({ type: data.method, message: data.args.join('') })
         }
       } else if (data.type === 'codepan-make-output-active') {
         this.setActivePan('output')

--- a/src/utils/proxy-console.js
+++ b/src/utils/proxy-console.js
@@ -169,6 +169,31 @@
       return newArgs
     }
 
+    /**
+     * Add colors for console string or fallback on stringifyArgs for non-string types
+     */
+    const handleArgs = function (args) {
+      if (!args || args.length === 0) return []
+
+      const string = args[0]
+      if (typeof string !== 'string') {
+        return stringifyArgs(args)
+      }
+
+      const textArray = string.split('%c')
+      const colors = textArray.length - 1
+      if (!colors) return [string]
+
+      const styleArray = []
+      for (let argIndex = 1; argIndex < args.length; argIndex++) {
+        styleArray.push(args[argIndex])
+      }
+
+      return textArray.map((text, index) => {
+        return index ? `<span style="${styleArray.shift()}">${text}</span>` : text
+      })
+    }
+
     // Create each of these methods on the proxy, and postMessage up to JS Bin
     // when one is called.
     const methods = (ProxyConsole.prototype.methods = [
@@ -204,7 +229,7 @@
       ProxyConsole.prototype[method] = function () {
         // Replace args that can't be sent through postMessage
         const originalArgs = [].slice.call(arguments)
-        const args = stringifyArgs(originalArgs)
+        const args = handleArgs(originalArgs)
 
         // Post up with method and the arguments
         window.parent.postMessage(

--- a/src/utils/proxy-console.js
+++ b/src/utils/proxy-console.js
@@ -182,7 +182,7 @@
 
       const textArray = string.split('%c')
       const colors = textArray.length - 1
-      if (!colors) return [string]
+      if (!colors || (colors === 1 && !textArray[1])) return [string]
 
       const styleArray = []
       for (let argIndex = 1; argIndex < args.length; argIndex++) {

--- a/src/utils/proxy-console.js
+++ b/src/utils/proxy-console.js
@@ -204,8 +204,11 @@
       const styles = []
       for (let i = 1; i < args.length; i++) {
         switch (replacements.shift().substr(0, 2)) {
-          case '%s': texts.push(args[i]); break
-          case '%c': styles.push(args[i]); break
+          case '%s': texts.push(args[i])
+            break
+          case '%c': styles.push(args[i])
+            break
+          default:
         }
       }
 


### PR DESCRIPTION
I've added support for:

`console.log('%cthis is colored text', 'color: red; background: pink;')`

since I work with `pixi.js` (`pixi-shim`) and they have a pretty colored hello message that was looking plain ugly

to see the message in action

1. add library `pixi-shim`
2. 
```
import {Application} from 'pixi-shim'
new Application
```
3. see console tab