### PR TITLE
Fix bug when passing multiple arguments to log

### DIFF
--- a/src/components/OutputPan.vue
+++ b/src/components/OutputPan.vue
@@ -141,7 +141,7 @@ export default {
         if (data.method === 'clear') {
           this.clearLogs()
         } else {
-          this.addLog({ type: data.method, message: data.args.join('') })
+          this.addLog({ type: data.method, message: data.args.join(' ') })
         }
       } else if (data.type === 'codepan-make-output-active') {
         this.setActivePan('output')

--- a/src/utils/proxy-console.js
+++ b/src/utils/proxy-console.js
@@ -172,7 +172,7 @@
     /**
      * Add colors for console string
      */
-    const styleText = function (textArray, styles) {
+    const styleText = function (textArray, styles = []) {
       return textArray.map((text, index) => {
         return index ? `<span style="${styles.shift()}">${text}</span>` : text
       })
@@ -200,6 +200,12 @@
       }
 
       const replacements = args[0].match(/(%[sc])([^%]*)/gm)
+
+      // If no replacement is found, we return a unstyled text
+      if (!replacements || replacements === null) {
+        return styleText(args);
+      }
+
       const texts = []
       const styles = []
       for (let i = 1; i < args.length; i++) {

--- a/src/utils/proxy-console.js
+++ b/src/utils/proxy-console.js
@@ -202,7 +202,7 @@
       const replacements = args[0].match(/(%[sc])([^%]*)/gm)
 
       // If no replacement is found, we return a unstyled text
-      if (!replacements || replacements === null) {
+      if (!replacements || !replacements.length) {
         return styleText(args);
       }
 

--- a/src/utils/proxy-console.js
+++ b/src/utils/proxy-console.js
@@ -174,7 +174,7 @@
      */
     const styleText = function (textArray, styles = []) {
       return textArray.map((text, index) => {
-        return index ? `<span style="${styles.shift()}">${text}</span>` : text
+        return index ? `<span style="${styles.shift()}">${stringify(text)}</span>` : text
       })
     }
 


### PR DESCRIPTION
hey!

really good playground, super nice, i already switch from jsbin to codepan 🥇 

i made this PR because i notice that when calling `console.log` with multiple arguments, the following error appears in the integrated console: 

<img width="837" alt="Screen Shot 2019-08-28 at 19 26 35" src="https://user-images.githubusercontent.com/13141462/63899155-c90a0f80-c9c9-11e9-8d43-e7ab15a32ecd.png">

the error was due to the support of styling logs, i just check if any styling is intended, and if is not, it should return an unstyled text, i also added a blank when joining arguments to have them separated, but i'm not aware of the use case of the previous way 

TODO:
- [x] Add support for arrays

please review @egoist @Prozi  :)